### PR TITLE
Fix parsing of TTL

### DIFF
--- a/mcshredder.c
+++ b/mcshredder.c
@@ -1827,6 +1827,7 @@ static int mcslib_client_write_mgres_to_ms(lua_State *L) {
                    p++;
                 } else {
                     memcpy(p, token+1, tlen-1);
+                    p += tlen-1;
                 }
                 *p = ' ';
                 p++;


### PR DESCRIPTION
TTL length is not accounted, and result in `CLIENT_ERROR bad token in command line format` errors

`ms /feihubesteffort/mcshredder/772694 10 F0 T q ME`

