### PR TITLE
TLS checkpoint: POC

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,4 +4,10 @@ all:
 		cd vendor/ && ${MAKE}
 		#gcc -g -O2 -pthread -Ivendor/lua/src -Ivendor/liburing/src/include -Wall -pedantic -o mcshredder mcshredder.c pcg-basic.c itoa_ljust.c $(LDFLAGS)
 		# sometimes helpful to add -fno-omit-frame-pointer for perf tracing
-		gcc -g -O2 -pthread -Ivendor/lua/src -Ivendor/liburing/src/include -Wall -pedantic -o mcshredder mcshredder.c itoa_ljust.c vendor/mcmc/mcmc.o vendor/lua/src/liblua.a vendor/liburing/src/liburing.a -lm $(LDFLAGS) -ldl
+		gcc -g -O2 -pthread -rdynamic -Ivendor/lua/src -Ivendor/liburing/src/include -Wall -pedantic -o mcshredder mcshredder.c itoa_ljust.c vendor/mcmc/mcmc.o vendor/lua/src/liblua.a vendor/liburing/src/liburing.a -lm $(LDFLAGS) -ldl
+
+tls:
+		cd vendor/ && ${MAKE}
+		# sometimes helpful to add -fno-omit-frame-pointer for perf tracing
+		gcc -g -O2 -pthread -rdynamic -Ivendor/lua/src -Ivendor/liburing/src/include -Wall -pedantic -o mcshredder mcshredder.c tls.c itoa_ljust.c vendor/mcmc/mcmc.o vendor/lua/src/liblua.a vendor/liburing/src/liburing.a -lcrypto -lssl -lm $(LDFLAGS) -ldl -DUSE_TLS=1
+

--- a/README.md
+++ b/README.md
@@ -41,6 +41,10 @@ Sorry about the bare makefile; low priority :)
 --port [11211]
  - port to connect to
 
+--tls
+ - Use TLS if compiled in (see below)
+```
+
 ## Configuration
 
 See conf/example.lua for an introduction to the configuration language.
@@ -48,3 +52,10 @@ See conf/example.lua for an introduction to the configuration language.
 Please keep in mind: This is a benchmark tool, and as such we try to minimize
 overhead. There is minimal argument checking, minimal error handling, etc. Try
 to keep configuration files straightforward and simple.
+
+## TLS
+
+With OpenSSL installed, run `make tls` to enable TLS mode. Note this feature
+is new as of July 2024 and has poor error handling. If you run into errors
+please let us know and we'll prioritize that fix. We'll be improving the TLS
+support on a low priority basis.

--- a/mcshredder.h
+++ b/mcshredder.h
@@ -1,6 +1,43 @@
 #ifndef MCS_H
 #define MCS_H
 
+#include <stdbool.h>
+
+// incomplete type for passing through to _evset functions
+struct mcs_func;
+struct mcs_func_client;
+
+#include "tls.h"
+
+// TODO: remove?
+typedef bool (*mcs_cfunc)(struct mcs_func *f, struct mcs_func_client *c);
+
+enum mcs_func_state {
+    mcs_fstate_disconn = 0,
+    mcs_fstate_connecting,
+    mcs_fstate_postconnect,
+    mcs_fstate_retry,
+    mcs_fstate_postretry,
+    mcs_fstate_run,
+    mcs_fstate_flush,
+    mcs_fstate_postflush,
+    mcs_fstate_read,
+    mcs_fstate_postread,
+    mcs_fstate_rerun,
+    mcs_fstate_restart,
+    mcs_fstate_syserr,
+    mcs_fstate_outwait,
+    mcs_fstate_sleep,
+    mcs_fstate_stop,
+    mcs_fstate_tls_hs,
+    mcs_fstate_tls_hs_postread,
+    mcs_fstate_tls_hs_postwrite,
+    mcs_fstate_tls_read,
+    mcs_fstate_tls_postread, // decrypt data then -> fstate_postread
+    mcs_fstate_tls_flush,
+    mcs_fstate_tls_postflush,
+};
+
 struct mcs_buf {
     int used; // total valid data filled
     int offset; // data sent/read
@@ -25,13 +62,34 @@ struct mcs_conn {
 // client object for custom funcs
 struct mcs_func_client {
     struct mcs_conn conn;
-#ifdef USE_TLS
-    struct mcs_tls_client tls;
-#endif
+    struct mcs_tls_client *tls;
+    struct mcs_func *parent; // function that owns this client.
     void *mcmc; // mcmc client object
     struct mcs_buf wb;
     struct mcs_buf rb;
+    enum mcs_func_state s_read;
+    enum mcs_func_state s_flush;
     bool connected;
 };
+
+void mcs_buf_init(struct mcs_buf *b, size_t size);
+
+// TODO: wrong, but trying to save some time.
+// need to end up with a libevent-like thing that wraps syscalls and gives you
+// callbacks, but I don't have epoll implemented to compare with and need to
+// refactor all of the uring code to get a proper abstract interface.
+//
+// In the meantime we do it halfway: let the TLS module swap around callbacks
+// and call into our uring code a little bit.
+void _evset_wrflush_data(struct mcs_func *f, struct mcs_func_client *c, char *data, long len);
+void _evset_read_data(struct mcs_func *f, struct mcs_func_client *c, char *data, long len);
+
+// return -1 if failure to get sqe
+typedef int (*queue_cb)(void *udata);
+int mcs_func_cqe_res(struct mcs_func *f);
+void mcs_func_set_cqe_res(struct mcs_func *f, int res);
+struct mcs_func_client *mcs_func_get_client(struct mcs_func *f);
+void mcs_func_set_state(struct mcs_func *f, enum mcs_func_state s);
+bool mcs_cm_postconnect(struct mcs_func *f, struct mcs_func_client *c);
 
 #endif // MCS_H

--- a/tls.c
+++ b/tls.c
@@ -1,0 +1,330 @@
+/* -*- Mode: C; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *  mc-shredder - burn-in load test client
+ *
+ *       https://github.com/memcached/mcshredder
+ *
+ *  Copyright 2024 Cache Forge LLC.  All rights reserved.
+ *
+ *  Use and distribution licensed under the BSD license.  See
+ *  the LICENSE file for full text.
+ *
+ *  Authors:
+ *      dormando <dormando@rydia.net>
+ */
+
+// General TODO's:
+// - implement syserr callback:
+//   - in mcs_syserror: if c.tls -> call back into tls for shutdown/free
+// - on syserror cases, differentiate the errors a little (ie; closed socket
+// vs syscall err vs ssl err
+// - implement syserr handling for cfunc state machine
+// - defines for state machine stop/go instead of true/false
+// - enum for yield return (see cfunc_run)
+// - graceful close: if c.tls/etc anywhere disconn is called, gracefully kill
+// SSL object.
+//
+// PERFORMANCE NOTE:
+// - in a simple test: 240k rps fetch with TLS, 350k without. haven't
+// inspected yet.
+
+#ifdef USE_TLS
+
+#include <string.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <pthread.h>
+#include <unistd.h>
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <netinet/in.h>
+#include <netinet/tcp.h>
+#include <arpa/inet.h>
+#include <netdb.h>
+#include <time.h>
+#include <stdbool.h>
+
+#include <openssl/ssl.h>
+#include <openssl/bio.h>
+#include <openssl/err.h>
+
+#include "mcshredder.h"
+#include "tls.h"
+
+// FIXME: needs to be higher than 2^14 to get a full TLS record in one go.
+// Hopefully with a future custom BIO we can read directly into the BIO memory
+// avoiding this extra bloat and data copy.
+#define MCS_TLS_RBUF_SIZE 1<<16
+
+struct mcs_tls_client {
+    SSL *ssl;
+    BIO *ibio; // staging input from network
+    BIO *obio; // staging output to network
+    int obio_remain; // remember our flush offset
+    struct mcs_buf rb; // internal read buffer.
+};
+
+// initialize a global OpenSSL context to use with creating connection SSL
+// objects.
+void *mcs_tls_init(void) {
+    // TODO: check for a reasonable OpenSSL version.
+    SSL_CTX *ctx = NULL;
+    OPENSSL_init_ssl(0, NULL);
+    ctx = SSL_CTX_new(TLS_client_method());
+    if (ctx == NULL) {
+        return NULL;
+    }
+
+    // disable older protocols
+    SSL_CTX_set_min_proto_version(ctx, TLS1_3_VERSION);
+    // TODO: check result in case of failure.
+    return ctx;
+}
+
+enum mcs_tls_ret mcs_tls_do_handshake(struct mcs_tls_client *c) {
+    if (SSL_is_init_finished(c->ssl)) {
+        return MCS_TLS_OK;
+    }
+
+    ERR_clear_error();
+    int n = SSL_do_handshake(c->ssl);
+    if (n == 1) {
+        return MCS_TLS_OK; // complete
+    }
+
+    int err = SSL_get_error(c->ssl, n);
+    if (err == SSL_ERROR_WANT_READ ||
+        err == SSL_ERROR_WANT_WRITE) {
+        // FIXME: should be able to directly return WANT_WRITE/WANT_READ
+        // properly from here using our internal buffers.
+        // Our custom BIO should either have bytes in it or we need to read.
+        ERR_clear_error();
+        return MCS_TLS_WANT_IO;
+    }
+
+    // else some real error.
+    ERR_print_errors_fp(stderr);
+    ERR_clear_error();
+    return MCS_TLS_ERROR;
+}
+
+bool mcs_tls_hs_postwrite(void *udata) {
+    struct mcs_func *f = udata;
+    int res = mcs_func_cqe_res(f);
+    struct mcs_func_client *c = mcs_func_get_client(f);
+
+    if (res > 0) {
+        c->tls->obio_remain -= res;
+        int remain = c->tls->obio_remain;
+        if (remain == 0) {
+            BIO_reset(c->tls->obio);
+            // complete, retry tls run.
+            return mcs_tls_postconnect(f, c);
+        } else {
+            char *data = NULL;
+            long len = BIO_get_mem_data(c->tls->obio, &data);
+            // still have something to write.
+            _evset_wrflush_data(f, c, data + (len - remain), remain);
+            return true;
+        }
+    } else {
+        ERR_print_errors_fp(stderr);
+        ERR_clear_error();
+        mcs_func_set_state(f, mcs_fstate_syserr);
+    }
+    return false;
+}
+
+bool mcs_tls_hs_postread(void *udata) {
+    struct mcs_func *f = udata;
+    int res = mcs_func_cqe_res(f);
+    struct mcs_func_client *c = mcs_func_get_client(f);
+
+    if (res > 0) {
+        BIO_write(c->tls->ibio, c->tls->rb.data, res);
+        // don't need to move the pointers around since we've memcpy'd
+        // everything useful here.
+        // TODO: there is potential error handling and BIO_write() will tell
+        // us how much was actually written; so deal with that.
+        return mcs_tls_postconnect(f, c); // retry handshake.
+    } else {
+        // need to set syserr failure mode
+        abort();
+    }
+
+    return false;
+}
+
+// TODO: if internal error, change func state to syserr
+bool mcs_tls_postconnect(struct mcs_func *f, struct mcs_func_client *c) {
+    enum mcs_tls_ret ret = mcs_tls_do_handshake(c->tls);
+
+    if (ret == MCS_TLS_OK) {
+        // good, call main postconnect routine
+        mcs_func_set_state(f, mcs_fstate_postconnect);
+        ERR_clear_error(); // clear for good measure.
+        return false;
+    } else if (ret == MCS_TLS_WANT_IO) {
+        // need to check if we need to read or write.
+        // sadly the handshake can say "WANT_READ" but will put bytes into the
+        // output BIO, so we need to duck-type the return by first checking if
+        // output bytes are pending.
+        if (BIO_pending(c->tls->obio)) {
+            // first do a write.
+            // directly reference the data in the memory BIO to avoid dealing
+            // with an extra buffer and data copy if possible.
+            char *data = NULL;
+            long len = BIO_get_mem_data(c->tls->obio, &data);
+            c->tls->obio_remain = len;
+            _evset_wrflush_data(f, c, data, len);
+            mcs_func_set_state(f, mcs_fstate_tls_hs_postwrite);
+            return true; // stop the parent state machine
+        } else {
+            // want read.
+            struct mcs_buf *rb = &c->tls->rb;
+            _evset_read_data(f, c, rb->data + rb->used, rb->size - rb->used);
+            mcs_func_set_state(f, mcs_fstate_tls_hs_postread);
+            return true; // stop parent state machine
+        }
+    } else {
+        abort();
+        // TODO: error. need to set state to syserr
+    }
+    return false; // don't stop the parent state machine
+}
+
+// FIXME: restrict amount of flushing at once to reduce memory footprint.
+bool mcs_tls_flush(struct mcs_func *f, struct mcs_func_client *c) {
+    char *todo = c->wb.data + c->wb.offset;
+    int remain = c->wb.used - c->wb.offset;
+
+    if (remain == 0) {
+        c->wb.used = 0;
+        c->wb.offset = 0;
+        mcs_func_set_state(f, mcs_fstate_run);
+        return false;
+    }
+
+    // Writes into the output memory BIO. We then need to run the syscall
+    // on our own.
+    int n = SSL_write(c->tls->ssl, todo, remain);
+
+    if (n < 0) {
+        // FIXME: WANT_IO
+        abort();
+    } else {
+        if (n < remain) {
+            abort(); // short read.
+        }
+        // advance the wbuf.
+        c->wb.offset += n;
+
+        char *data = NULL;
+        long len = BIO_get_mem_data(c->tls->obio, &data);
+        c->tls->obio_remain = len;
+        _evset_wrflush_data(f, c, data, len);
+        mcs_func_set_state(f, mcs_fstate_tls_postflush);
+        return true; // stop state machine.
+    }
+
+    return false;
+}
+
+bool mcs_tls_postflush(struct mcs_func *f, struct mcs_func_client *c) {
+    int res = mcs_func_cqe_res(f);
+
+    if (res > 0) {
+        c->tls->obio_remain -= res;
+        int remain = c->tls->obio_remain;
+        if (remain == 0) {
+            BIO_reset(c->tls->obio);
+            // complete, move on.
+            mcs_func_set_state(f, mcs_fstate_tls_flush);
+        } else {
+            char *data = NULL;
+            long len = BIO_get_mem_data(c->tls->obio, &data);
+            // didn't flush everything.
+            _evset_wrflush_data(f, c, data + (len - remain), remain);
+            return true; // stop state machine
+        }
+    } else {
+        abort(); // error handler.
+    }
+
+    return false;
+}
+
+bool mcs_tls_read(struct mcs_func *f, struct mcs_func_client *c) {
+    struct mcs_buf *rb = &c->tls->rb;
+    _evset_read_data(f, c, rb->data + rb->used, rb->size - rb->used);
+    mcs_func_set_state(f, mcs_fstate_tls_postread);
+
+    return true;
+}
+
+bool mcs_tls_postread(struct mcs_func *f, struct mcs_func_client *c) {
+    int res = mcs_func_cqe_res(f);
+
+    if (res > 0) {
+        // Move our read buffer data into the encryption input buffer.
+        BIO_write(c->tls->ibio, c->tls->rb.data, res);
+        // Decrypt the data into our application read buffer.
+        int n = SSL_read(c->tls->ssl, c->rb.data + c->rb.used, c->rb.size - c->rb.used);
+
+        if (n < 0) {
+            // TODO: ERR_clear_error()
+            int err = SSL_get_error(c->tls->ssl, n);
+            if (err == SSL_ERROR_WANT_WRITE ||
+                err == SSL_ERROR_WANT_READ) {
+                if (BIO_pending(c->tls->obio)) {
+                    char *data = NULL;
+                    long len = BIO_get_mem_data(c->tls->obio, &data);
+                    _evset_wrflush_data(f, c, data, len);
+                    abort(); // TODO: need another stupid state to ensure we
+                             // do BIO_seek()?
+                    return true; // stop the parent state machine
+                } else {
+                    // want read.
+                    mcs_func_set_state(f, c->s_read);
+                    return false; // bounce back through the read routine.
+                }
+            } else {
+                ERR_print_errors_fp(stderr);
+                abort(); // unknown error.
+            }
+        } else {
+            mcs_func_set_cqe_res(f, n);
+            mcs_func_set_state(f, mcs_fstate_postread);
+            return false; // don't stop state machine
+        }
+    } else {
+        abort();
+        // error handler.
+    }
+
+    return true;
+}
+
+int mcs_tls_client_init(struct mcs_func_client *fc, void *ctx) {
+    struct mcs_tls_client *c = calloc(1, sizeof(*c));
+    c->ssl = SSL_new((SSL_CTX *)ctx);
+    if (c->ssl == NULL)
+        return -1;
+
+    c->ibio = BIO_new(BIO_s_mem());
+    c->obio = BIO_new(BIO_s_mem());
+    mcs_buf_init(&c->rb, MCS_TLS_RBUF_SIZE);
+
+    SSL_set_connect_state(c->ssl);
+    SSL_set0_rbio(c->ssl, c->ibio);
+    SSL_set0_wbio(c->ssl, c->obio);
+
+    fc->tls = c;
+    fc->s_read = mcs_fstate_tls_read;
+    fc->s_flush = mcs_fstate_tls_flush;
+
+    return 0;
+}
+
+#endif // USE_TLS

--- a/tls.h
+++ b/tls.h
@@ -1,0 +1,40 @@
+#ifndef MCS_TLS_H
+#define MCS_TLS_H
+
+enum mcs_tls_ret {
+    MCS_TLS_OK = 1,
+    MCS_TLS_WANT_READ,
+    MCS_TLS_WANT_WRITE,
+    MCS_TLS_WANT_IO,
+    MCS_TLS_ERROR,
+};
+
+struct mcs_tls_client;
+
+#define TLS_BUF_SIZE_DEFAULT 8192
+
+#ifdef USE_TLS
+void *mcs_tls_init(void);
+int mcs_tls_client_init(struct mcs_func_client *fc, void *ctx);
+enum mcs_tls_ret mcs_tls_do_handshake(struct mcs_tls_client *c);
+// FIXME: -> handshake?
+bool mcs_tls_postconnect(struct mcs_func *f, struct mcs_func_client *c);
+bool mcs_tls_hs_postwrite(void *udata);
+bool mcs_tls_hs_postread(void *udata);
+bool mcs_tls_read(struct mcs_func *f, struct mcs_func_client *c);
+bool mcs_tls_postread(struct mcs_func *f, struct mcs_func_client *c);
+bool mcs_tls_flush(struct mcs_func *f, struct mcs_func_client *c);
+bool mcs_tls_postflush(struct mcs_func *f, struct mcs_func_client *c);
+#else
+#define mcs_tls_init(void)
+#define mcs_tls_client_init(fc, ctx)
+#define mcs_tls_postconnect(f, c) false
+#define mcs_tls_hs_postwrite(u) false
+#define mcs_tls_hs_postread(u) false
+#define mcs_tls_read(f, c) false
+#define mcs_tls_postread(f, c) false
+#define mcs_tls_flush(f, c) false
+#define mcs_tls_postflush(f, c) false
+#endif // USE_TLS
+
+#endif // MCS_TLS_H


### PR DESCRIPTION
This is a second attempt at integrating OpenSSL with io_uring for mcshredder.

- This is mostly working, but filled with `abort()`'s for sections of unfinished error handling.
- Uses too much memory when flushing to the socket (not a problem outside of huge data flushes)
- Probably some remaining inefficiencies.
- New code keeps all of the OpenSSL junk in `tls.c`, minimizing change in the main code.

Instead of using a custom `BIO` like my first attempt I've gone back to using a `BIO_s_mem`. This uses a trick to directly access the "output" BIO memory to avoid double-copying and double-buffering for writes, but reads are still double buffered. The double copy and extra memory usage may improved by further hacks or a custom BIO in the future.

Note: Mainly I haven't figured out a way to move the `BIO_s_mem`'s read pointer without having it memcpy data somewhere. I vaguely recall seeing the interface somewhere so it should be possible: if so we can parse directly out of the BIO. This is fine for mcshredder since we're in a test environment and having _some_ memory inefficiencies with the permament `BIO` memory buffers is fine. However in the future we should get a custom BIO working so we can release read/write buffers when unused.

Timing:

Still a slow burn. Since the tls code is contained in its own file I may merge this early and leave a caveat, then slowly work through the abort()'s as I make use of it.