### PR TITLE
Updating `mcs.read()` in the example Lua files

### DIFF
--- a/conf/example.lua
+++ b/conf/example.lua
@@ -74,7 +74,8 @@ function warm()
     local req = mcs.set("doot", counter, 0, 300, 50)
     mcs.write(req)
     mcs.flush()
-    local res = mcs.read()
+    local res = mcs.res_new()
+    mcs.read(res)
     counter = counter + 1
 end
 
@@ -96,7 +97,8 @@ function basic()
     mcs.flush()
 
     -- wait for a response and parse it into a response object.
-    local res = mcs.read()
+    local res = mcs.res_new()
+    mcs.read(res)
     -- NOTE: a response object is only valid until the next time mcs.read() is
     -- called: res points directly into the client read buffer, which moves
     -- every time read() is called.
@@ -107,11 +109,13 @@ function basic()
         local set = mcs.set("toast/", num, 0, 90, 100)
         mcs.write(set)
         mcs.flush()
-        local res = mcs.read()
+        local res = mcs.res_new()
+        mcs.read(res)
         -- note validating the response here is optional.
     else
         -- If we got a hit, we need to still read the END marker.
-        local res = mcs.read()
+        local res = mcs.res_new()
+        mcs.read(res)
         -- note we're not validating the END marker here.
     end
 end
@@ -121,12 +125,14 @@ function metaget()
     local req = mcs.mg("toast/", num, "v")
     mcs.write(req)
     mcs.flush()
-    local res = mcs.read()
+    local res = mcs.res_new()
+    mcs.read(res)
     if mcs.resline(res) == "EN" then
         local set = mcs.ms("toast/", num, 50, "T90")
         mcs.write(set)
         mcs.flush()
-        local res = mcs.read()
+        local res = mcs.res_new()
+        mcs.read(res)
     else
         local status, elapsed = mcs.match(req, res)
         if not status then
@@ -143,7 +149,8 @@ function latency()
     mcs.write(req)
     mcs.flush()
 
-    local res = mcs.read()
+    local res = mcs.res_new()
+    mcs.read(res)
     -- NOTE: as of writing "status" is meaningless.
     -- mcs.match(req, res) will do basic validation that the response makes
     -- sense for the request.
@@ -167,7 +174,8 @@ function statsample()
     mcs.flush()
     local stats = {}
     while true do
-        local res = mcs.read()
+        local res = mcs.res_new()
+        mcs.read(res)
         if mcs.resline(res) == "END" then
             break
         end
@@ -184,5 +192,3 @@ function statsample()
     previous_stats = stats
     stats_ready = true
 end
-
-

--- a/conf/metafactory.lua
+++ b/conf/metafactory.lua
@@ -42,21 +42,21 @@ function basic(a)
     local pfx = a.prefix
     local size = a.vsize
     local req = mcs.mg_factory(pfx, "v")
-    local res = mcs.res_new()
+    local set_res = mcs.res_new()
 
     return function()
         local num = math.random(total)
         mcs.write_factory(req, num)
         mcs.flush()
 
-        mcs.read(res)
-        if mcs.res_startswith(res, "EN") then
+        mcs.read(set_res)
+        if mcs.res_startswith(set_res, "EN") then
             print("miss")
 --[[
             local set = mcs.set(prefix, num, 0, 30, size)
             mcs.write(set)
             mcs.flush()
-            local res = mcs.read()
+            mcs.read(set_res)
 --]]
         end
     end
@@ -80,7 +80,8 @@ function basic_noinit(a)
         local set = mcs.set(a.prefix, num, 0, 30, a.vsize)
         mcs.write(set)
         mcs.flush()
-        local res = mcs.read()
+        local res = mcs.res_new()
+        mcs.read(res)
     end
 --]]
 end
@@ -133,5 +134,3 @@ function statsample()
     previous_stats = stats
     stats_ready = true
 end
-
-


### PR DESCRIPTION
Updating `mcs.read()` in the example Lua files to incorporate the API change for `mcslib_read()` introduced in this previous change: https://github.com/memcached/mcshredder/commit/011b36b372de086c1ccfa7d1b89e703d8b195fdd 

### Test 
I was able to run `mcshredder` using the updated `example.lua` (with key prefix set to some actual value). I did `watch proxyreqs` with sampling disabled and could see below from the proxy:
```
...
ts=1724284316.964780 gid=518230 type=proxy_req elapsed=755 type=101 code=15 status=0 cfd=0 be=10.100.88.89:11216 detail=fg_cache_hit req=mg /test/14 v
...
```